### PR TITLE
Fixed race condition cauzing application crash on Android.

### DIFF
--- a/Source/AugmentedUnreality/AURDriver.cpp
+++ b/Source/AugmentedUnreality/AURDriver.cpp
@@ -82,10 +82,12 @@ void UAURDriver::WriteFrameToTexture()
 		UpdateTextureRenderCommand,
 		FTextureUpdateParameters*, UpdateParameters, &this->TextureUpdateParameters,
 		{
-			if (UpdateParameters->Texture2DResource && UpdateParameters->Texture2DResource->GetCurrentFirstMip() <= 0)
+			if (UpdateParameters->Texture2DResource 
+					&& UpdateParameters->Texture2DResource->GetCurrentFirstMip() <= 0 
+					&& UpdateParameters->Texture2DResource->GetTexture2DRHI())
 			{
 				// Re-draw only if a new frame has been captured
-				if (UpdateParameters->Driver->IsNewFrameAvailable())
+				if (UpdateParameters->Driver && UpdateParameters->Driver->IsNewFrameAvailable())
 				{
 					FAURVideoFrame* new_video_frame = UpdateParameters->Driver->GetFrame();
 


### PR DESCRIPTION
Adynathos,
Hello.

I am currently using this plugin to develop an Android application and I came across this bug.

The bug can be reproduced by launching an application with AURCameraActor set as default actor and with camera feed opening as default video source. That being said, launching with no video seems to work fine. Right after splash screen, the application "freezes" with some ripples on the screen and shortly crashes.

Using logcat I was able to retrieve the following backtrace from the crashed app:

> --------- beginning of crash
> F/libc    ( 6285): Fatal signal 11 (SIGSEGV), code 1, fault addr 0x50 in tid 6489 (RenderThread 1)
> D/clmlib  (  408): Got activities:0x0000000E
> I/DEBUG   (  408): *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
> I/DEBUG   (  408): UUID: e28a0bfe-226d-4d45-a1c2-2f178a4bad65
> I/DEBUG   (  408): Build fingerprint: 'Sony/SGP321/SGP321:5.1.1/10.7.A.0.222/2921970873:user/release-keys'
> I/DEBUG   (  408): Revision: '0'
> I/DEBUG   (  408): ABI: 'arm'
> I/DEBUG   (  408): pid: 6285, tid: 6489, name: RenderThread 1  >>> com.gordeevbr.demo <<<
> I/DEBUG   (  408): signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x50
> I/DEBUG   (  408):     r0 00000000  r1 96003c80  r2 19594001  r3 00001959
> I/DEBUG   (  408):     r4 8ce6c000  r5 00000280  r6 988fe734  r7 00000000
> I/DEBUG   (  408):     r8 00008e76  r9 00270400  sl 988fe738  fp 9189baa0
> I/DEBUG   (  408):     ip a2fe7bd4  sp 9189ba08  lr b6e12287  pc a0f58530  cpsr 60070010
> I/DEBUG   (  408): 
> I/DEBUG   (  408): backtrace:
> I/DEBUG   (  408):     #00 pc 05543530  /data/app/com.gordeevbr.demo-1/lib/arm/libUE4.so (UAURDriver::WriteFrameToTexture())
> I/DEBUG   (  408):     #01 pc 0555b3cc  /data/app/com.gordeevbr.demo-1/lib/arm/libUE4.so (FAURVideoConfiguration::FAURVideoConfiguration(FAURVideoConfiguration const&))
> I/DEBUG   (  408):     #02 pc 01e989e0  /data/app/com.gordeevbr.demo-1/lib/arm/libUE4.so (FNamedTaskThread::ProcessTasksNamedThread(int, bool)+8492)
> I/DEBUG   (  408):     #03 pc 01e96114  /data/app/com.gordeevbr.demo-1/lib/arm/libUE4.so (FNamedTaskThread::ProcessTasksUntilQuit(int)+176)
> I/DEBUG   (  408):     #04 pc 043a838c  /data/app/com.gordeevbr.demo-1/lib/arm/libUE4.so (RenderingThreadMain(FEvent*)+252)
> I/DEBUG   (  408):     #05 pc 043b5914  /data/app/com.gordeevbr.demo-1/lib/arm/libUE4.so (FRenderingThread::Run()+20)
> I/DEBUG   (  408):     #06 pc 01f02730  /data/app/com.gordeevbr.demo-1/lib/arm/libUE4.so (FRunnableThreadPThread::Run()+284)
> I/DEBUG   (  408):     #07 pc 01e913a0  /data/app/com.gordeevbr.demo-1/lib/arm/libUE4.so (FRunnableThreadPThread::_ThreadProc(void*)+176)
> I/DEBUG   (  408):     #08 pc 000135e7  /system/lib/libc.so (__pthread_start(void*)+30)
> I/DEBUG   (  408):     #09 pc 00011513  /system/lib/libc.so (__start_thread+6)

Lines 00 and 01 of backtrace I had to retrieve with addr2line.

After inspecting every variable in the 'ENQUEUE_UNIQUE_RENDER_COMMAND_ONEPARAMETER' block of 'UAURDriver::WriteFrameToTexture()' for null pointers, I noticed that indeed 'UpdateParameters->Texture2DResource->GetTexture2DRHI()' sometimes returned null pointer just right before the crash. My guess is that this is a race condition.

After applying changes from this commit, I was not able to reproduce the error anymore. Please review it and accept if necessary.