### PR TITLE
bug: fixed race condition on VideoPropertiesChange

### DIFF
--- a/Source/AugmentedUnreality/AURDriverThreaded.cpp
+++ b/Source/AugmentedUnreality/AURDriverThreaded.cpp
@@ -120,7 +120,9 @@ void UAURDriverThreaded::NotifyVideoPropertiesChange()
 {
 	AsyncTask(ENamedThreads::GameThread, [this]() {
 		UE_LOG(LogAUR, Log, TEXT("NotifyVideoSourceStatusChange"))
-		this->OnVideoPropertiesChange.Broadcast(this);
+		if (GetCurrentDriver() != nullptr) {
+			this->OnVideoPropertiesChange.Broadcast(this);
+		}
 	});
 }
 


### PR DESCRIPTION
This pull request fixes issue https://github.com/adynathos/AugmentedUnreality/issues/24

It seems like a NotifyVideoPropertiesChange is triggered when the application quits, and so the driver is already unregistered.